### PR TITLE
Make Eclipse setup more portable

### DIFF
--- a/SECMockUp/.classpath
+++ b/SECMockUp/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleMQTTClient/.classpath
+++ b/SampleMQTTClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleProtobufClient/.classpath
+++ b/SampleProtobufClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleRESTClient/.classpath
+++ b/SampleRESTClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleRESTServer/.classpath
+++ b/SampleRESTServer/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleSerialClient/.classpath
+++ b/SampleSerialClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleTCPClient/.classpath
+++ b/SampleTCPClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleTCPServer/.classpath
+++ b/SampleTCPServer/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>

--- a/SampleUDPClient/.classpath
+++ b/SampleUDPClient/.classpath
@@ -12,37 +12,37 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcpkix-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcprov-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Bouncycastle/bcutil-jdk18on-1.80-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Gson/gson-2.11.0.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Gson/gson-2.11.0-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Projekte/VolkerVoss/SEDAP-Express/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
+	<classpathentry kind="lib" path="/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/SEDAPExpress/libs/Protobuf/protobuf-java-util-4.28.1-javadoc.jar!/"/>
 			<attribute name="module" value="true"/>


### PR DESCRIPTION
While working on the EDTH hackaton in Berlin, I have configured an Eclipse workspace (on Windows). Just a few modifications to the files (mostly .classpath) where needed, so I thought I would gather them in this PR.

Except for ./MessageTool (where there were other issues, so I left it aside completely) all projects should now import properly in Eclipse, as long as the `JavaFx ` and `JUnit ` user libraries are configured at workspace level with the relevant jar files.